### PR TITLE
Receive strategy type

### DIFF
--- a/samples/echo/LiteNetwork.Sample.Echo.Server/Program.cs
+++ b/samples/echo/LiteNetwork.Sample.Echo.Server/Program.cs
@@ -7,7 +7,10 @@ namespace LiteNetwork.Sample.Echo.Server
     {
         static void Main(string[] args)
         {
-            var configuration = new LiteServerConfiguration("127.0.0.1", 4444);
+            var configuration = new LiteServerConfiguration("127.0.0.1", 4444)
+            {
+                ReceiveStrategy = Common.ReceiveStrategyType.Queued
+            };
             using var server = new EchoServer(configuration);
 
             server.Start();

--- a/src/LiteNetwork.Common/ILiteConnection.cs
+++ b/src/LiteNetwork.Common/ILiteConnection.cs
@@ -4,6 +4,9 @@ using System.Threading.Tasks;
 
 namespace LiteNetwork.Common
 {
+    /// <summary>
+    /// Provides an abstraction that represents a living connection.
+    /// </summary>
     public interface ILiteConnection
     {
         /// <summary>

--- a/src/LiteNetwork.Common/ILiteConnectionToken.cs
+++ b/src/LiteNetwork.Common/ILiteConnectionToken.cs
@@ -1,9 +1,10 @@
 ﻿using LiteNetwork.Protocol;
+using System;
 using System.Net.Sockets;
 
 namespace LiteNetwork.Common
 {
-    public interface ILiteConnectionToken
+    public interface ILiteConnectionToken : IDisposable
     {
         /// <summary>
         /// Gets the connection attached to the current token.
@@ -19,5 +20,11 @@ namespace LiteNetwork.Common
         /// Gets the data token.
         /// </summary>
         LiteDataToken DataToken { get; }
+
+        /// <summary>
+        /// Adds the given message buffer into the received message queue.
+        /// </summary>
+        /// <param name="message">Message data buffer to add.</param>
+        void EnqueueMessage(byte[] message);
     }
 }

--- a/src/LiteNetwork.Common/Internal/LiteConnectionToken.cs
+++ b/src/LiteNetwork.Common/Internal/LiteConnectionToken.cs
@@ -1,5 +1,9 @@
 ﻿using LiteNetwork.Protocol;
+using System;
+using System.Collections.Concurrent;
 using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace LiteNetwork.Common.Internal
 {
@@ -8,6 +12,14 @@ namespace LiteNetwork.Common.Internal
     /// </summary>
     internal class LiteConnectionToken : ILiteConnectionToken
     {
+        private readonly ReceiveStrategyType _receiveStrategy;
+        private readonly Func<ILiteConnection, byte[], Task> _handlerAction;
+
+        private readonly BlockingCollection<byte[]> _receiveMessageQueue = null!;
+        private readonly Task _receiveTask = null!;
+        private readonly CancellationToken _receiveCancellationToken;
+        private readonly CancellationTokenSource _receiveCancellationTokenSource = null!;
+
         /// <inheritdoc />
         public ILiteConnection Connection { get; }
 
@@ -23,11 +35,75 @@ namespace LiteNetwork.Common.Internal
         /// </summary>
         /// <param name="connection">Current connection.</param>
         /// <param name="socket">Current socket connection.</param>
-        public LiteConnectionToken(ILiteConnection connection, Socket socket)
+        /// <param name="receiveStrategy">Receive strategy.</param>
+        /// <param name="handlerAction">Action to execute when a packet message is being processed.</param>
+        public LiteConnectionToken(ILiteConnection connection, Socket socket, ReceiveStrategyType receiveStrategy, Func<ILiteConnection, byte[], Task> handlerAction)
         {
             Connection = connection;
             Socket = socket;
+            _receiveStrategy = receiveStrategy;
+            _handlerAction = handlerAction;
             DataToken = new LiteDataToken();
+
+            if (_receiveStrategy == ReceiveStrategyType.Queued)
+            {
+                _receiveMessageQueue = new BlockingCollection<byte[]>();
+                _receiveCancellationTokenSource = new CancellationTokenSource();
+                _receiveCancellationToken = _receiveCancellationTokenSource.Token;
+                _receiveTask = Task.Factory.StartNew(OnProcessMessageQueue, 
+                    _receiveCancellationToken, 
+                    TaskCreationOptions.LongRunning, 
+                    TaskScheduler.Default);
+            }
+        }
+
+        /// <inheritdoc />
+        public void EnqueueMessage(byte[] message)
+        {
+            if (_receiveStrategy == ReceiveStrategyType.Queued)
+            {
+                _receiveMessageQueue.Add(message);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_receiveStrategy == ReceiveStrategyType.Queued)
+            {
+                _receiveCancellationTokenSource.Cancel();
+
+                while (_receiveMessageQueue.Count > 0)
+                {
+                    _receiveMessageQueue.Take();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Task that processed the received message queue until its cancellation is requested.
+        /// </summary>
+        /// <returns></returns>
+        private async Task OnProcessMessageQueue()
+        {
+            if (_receiveStrategy != ReceiveStrategyType.Queued)
+            {
+                return;
+            }
+
+            while (!_receiveCancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    byte[] message = _receiveMessageQueue.Take(_receiveCancellationToken);
+
+                    await _handlerAction(Connection, message).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // The operation has been cancelled: nothing to do
+                }
+            }
         }
     }
 }

--- a/src/LiteNetwork.Common/Internal/LiteReceiver.cs
+++ b/src/LiteNetwork.Common/Internal/LiteReceiver.cs
@@ -51,7 +51,7 @@ namespace LiteNetwork.Common.Internal
         /// <param name="socket">User socket.</param>
         public void StartReceiving(ILiteConnection connection, Socket socket)
         {
-            var token = new LiteConnectionToken(connection, socket, ReceiveStrategy, ProcessReceivedMessage);
+            var token = new LiteReceiverConnectionToken(connection, socket, ReceiveStrategy, ProcessReceivedMessage);
             SocketAsyncEventArgs socketAsyncEvent = GetSocketEvent();
             socketAsyncEvent.UserToken = token;
 

--- a/src/LiteNetwork.Common/Internal/LiteReceiverConnectionToken.cs
+++ b/src/LiteNetwork.Common/Internal/LiteReceiverConnectionToken.cs
@@ -10,13 +10,12 @@ namespace LiteNetwork.Common.Internal
     /// <summary>
     /// Provides a data structure representing a lite connection token used for the receive process.
     /// </summary>
-    internal class LiteConnectionToken : ILiteConnectionToken
+    internal class LiteReceiverConnectionToken : ILiteConnectionToken
     {
         private readonly ReceiveStrategyType _receiveStrategy;
         private readonly Func<ILiteConnection, byte[], Task> _handlerAction;
 
         private readonly BlockingCollection<byte[]> _receiveMessageQueue = null!;
-        private readonly Task _receiveTask = null!;
         private readonly CancellationToken _receiveCancellationToken;
         private readonly CancellationTokenSource _receiveCancellationTokenSource = null!;
 
@@ -30,14 +29,14 @@ namespace LiteNetwork.Common.Internal
         public LiteDataToken DataToken { get; }
 
         /// <summary>
-        /// Creates a new <see cref="LiteConnectionToken"/> instance with a <see cref="ILiteConnection"/>
+        /// Creates a new <see cref="LiteReceiverConnectionToken"/> instance with a <see cref="ILiteConnection"/>
         /// and a <see cref="System.Net.Sockets.Socket"/>.
         /// </summary>
         /// <param name="connection">Current connection.</param>
         /// <param name="socket">Current socket connection.</param>
         /// <param name="receiveStrategy">Receive strategy.</param>
         /// <param name="handlerAction">Action to execute when a packet message is being processed.</param>
-        public LiteConnectionToken(ILiteConnection connection, Socket socket, ReceiveStrategyType receiveStrategy, Func<ILiteConnection, byte[], Task> handlerAction)
+        public LiteReceiverConnectionToken(ILiteConnection connection, Socket socket, ReceiveStrategyType receiveStrategy, Func<ILiteConnection, byte[], Task> handlerAction)
         {
             Connection = connection;
             Socket = socket;
@@ -50,7 +49,7 @@ namespace LiteNetwork.Common.Internal
                 _receiveMessageQueue = new BlockingCollection<byte[]>();
                 _receiveCancellationTokenSource = new CancellationTokenSource();
                 _receiveCancellationToken = _receiveCancellationTokenSource.Token;
-                _receiveTask = Task.Factory.StartNew(OnProcessMessageQueue, 
+                Task.Factory.StartNew(OnProcessMessageQueue, 
                     _receiveCancellationToken, 
                     TaskCreationOptions.LongRunning, 
                     TaskScheduler.Default);

--- a/src/LiteNetwork.Common/ReceiveStrategyType.cs
+++ b/src/LiteNetwork.Common/ReceiveStrategyType.cs
@@ -1,0 +1,18 @@
+﻿namespace LiteNetwork.Common
+{
+    /// <summary>
+    /// Defines the different receive strategy types available.
+    /// </summary>
+    public enum ReceiveStrategyType
+    {
+        /// <summary>
+        /// The default strategy. Handles the incoming packets right after they got received.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Place the received packet into a receive queue. The packet will be processed in the same order it got received.
+        /// </summary>
+        Queued
+    }
+}

--- a/src/LiteNetwork.Server/Internal/LiteReceivedMessage.cs
+++ b/src/LiteNetwork.Server/Internal/LiteReceivedMessage.cs
@@ -1,0 +1,40 @@
+﻿using LiteNetwork.Common;
+using System;
+using System.Threading.Tasks;
+
+namespace LiteNetwork.Server.Internal
+{
+    /// <summary>
+    /// Provides a simple data structure for a received message.
+    /// </summary>
+    internal class LiteReceivedMessage
+    {
+        private readonly Func<ILiteConnection, byte[], Task> _handler;
+        private readonly ILiteConnection _connection;
+        private readonly byte[] _message;
+
+        /// <summary>
+        /// Creates a new <see cref="LiteReceivedMessage"/> instance.
+        /// </summary>
+        /// <param name="connection">Connection that received the message.</param>
+        /// <param name="message">Current message byte array.</param>
+        /// <param name="handle">Handler to process data.</param>
+        public LiteReceivedMessage(ILiteConnection connection, byte[] message, Func<ILiteConnection, byte[], Task> handle)
+        {
+            _connection = connection;
+            _message = message;
+            _handler = handle;
+        }
+
+        /// <summary>
+        /// Handles the current received message.
+        /// </summary>
+        /// <remarks>
+        /// This methods call the handler given as constructor parameter and is executed in a parallel task.
+        /// </remarks>
+        public void Handle()
+        {
+            Task.Run(() => _handler(_connection, _message));
+        }
+    }
+}

--- a/src/LiteNetwork.Server/Internal/LiteServerReceiver.cs
+++ b/src/LiteNetwork.Server/Internal/LiteServerReceiver.cs
@@ -2,9 +2,7 @@
 using LiteNetwork.Common.Internal;
 using LiteNetwork.Protocol.Abstractions;
 using Microsoft.Extensions.ObjectPool;
-using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Net.Sockets;
 
 namespace LiteNetwork.Server.Internal
@@ -16,21 +14,19 @@ namespace LiteNetwork.Server.Internal
     {
         private readonly ObjectPool<SocketAsyncEventArgs> _readPool;
         private readonly int _clientBufferSize;
-        private readonly ReceiveStrategyType _receiveStrategy;
 
         /// <summary>
         /// Creates a new <see cref="LiteServerReceiver"/> instance with the given <see cref="ILitePacketProcessor"/>
         /// and a client buffer size.
         /// </summary>
         /// <param name="packetProcessor">Current packet processor used in the server.</param>
-        /// <param name="clientBufferSize">Client buffer size defined in server configuration.</param>
         /// <param name="receiveStrategy">The receive strategy type for every received message.</param>
-        public LiteServerReceiver(ILitePacketProcessor packetProcessor, int clientBufferSize, ReceiveStrategyType receiveStrategy) 
-            : base(packetProcessor)
+        /// <param name="clientBufferSize">Client buffer size defined in server configuration.</param>
+        public LiteServerReceiver(ILitePacketProcessor packetProcessor, ReceiveStrategyType receiveStrategy, int clientBufferSize) 
+            : base(packetProcessor, receiveStrategy)
         {
             _readPool = ObjectPool.Create<SocketAsyncEventArgs>();
             _clientBufferSize = clientBufferSize;
-            _receiveStrategy = receiveStrategy;
         }
 
         /// <inheritdoc />
@@ -54,26 +50,6 @@ namespace LiteNetwork.Server.Internal
             socketAsyncEvent.Completed += OnCompleted;
 
             return socketAsyncEvent;
-        }
-
-        protected override void ProcessReceivedMessages(ILiteConnectionToken connectionToken, IEnumerable<byte[]> messages)
-        {
-            if (connectionToken.Connection is not LiteServerUser serverUser)
-            {
-                throw new InvalidOperationException("Connection is not a server user.");
-            }
-
-            if (_receiveStrategy == ReceiveStrategyType.Default)
-            {
-                base.ProcessReceivedMessages(connectionToken, messages);
-            }
-            else if (_receiveStrategy == ReceiveStrategyType.Queued)
-            {
-                foreach (byte[] message in messages)
-                {
-                    serverUser.EnqueueReceivedMessage(new LiteReceivedMessage(connectionToken.Connection, message, ProcessReceivedMessage));
-                }
-            }
         }
     }
 }

--- a/src/LiteNetwork.Server/Internal/LiteServerReceiver.cs
+++ b/src/LiteNetwork.Server/Internal/LiteServerReceiver.cs
@@ -1,7 +1,10 @@
-﻿using LiteNetwork.Common.Internal;
+﻿using LiteNetwork.Common;
+using LiteNetwork.Common.Internal;
 using LiteNetwork.Protocol.Abstractions;
 using Microsoft.Extensions.ObjectPool;
+using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Net.Sockets;
 
 namespace LiteNetwork.Server.Internal
@@ -13,17 +16,20 @@ namespace LiteNetwork.Server.Internal
     {
         private readonly ObjectPool<SocketAsyncEventArgs> _readPool;
         private readonly int _clientBufferSize;
+        private readonly ReceiveStrategyType _receiveStrategy;
 
         /// <summary>
         /// Creates a new <see cref="LiteServerReceiver"/> instance.
         /// </summary>
         /// <param name="packetProcessor">Current packet processor used in the server.</param>
         /// <param name="clientBufferSize">Client buffer size defined in server configuration.</param>
-        public LiteServerReceiver(ILitePacketProcessor packetProcessor, int clientBufferSize) 
+        /// <param name="receiveStrategy">The receive strategy type for every received message.</param>
+        public LiteServerReceiver(ILitePacketProcessor packetProcessor, int clientBufferSize, ReceiveStrategyType receiveStrategy) 
             : base(packetProcessor)
         {
             _readPool = ObjectPool.Create<SocketAsyncEventArgs>();
             _clientBufferSize = clientBufferSize;
+            _receiveStrategy = receiveStrategy;
         }
 
         /// <inheritdoc />
@@ -47,6 +53,26 @@ namespace LiteNetwork.Server.Internal
             socketAsyncEvent.Completed += OnCompleted;
 
             return socketAsyncEvent;
+        }
+
+        protected override void ProcessReceivedMessages(ILiteConnectionToken connectionToken, IEnumerable<byte[]> messages)
+        {
+            if (connectionToken.Connection is not LiteServerUser serverUser)
+            {
+                throw new InvalidOperationException("Connection is not a server user.");
+            }
+
+            if (_receiveStrategy == ReceiveStrategyType.Default)
+            {
+                base.ProcessReceivedMessages(connectionToken, messages);
+            }
+            else if (_receiveStrategy == ReceiveStrategyType.Queued)
+            {
+                foreach (byte[] message in messages)
+                {
+                    serverUser.EnqueueReceivedMessage(new LiteReceivedMessage(connectionToken.Connection, message, ProcessReceivedMessage));
+                }
+            }
         }
     }
 }

--- a/src/LiteNetwork.Server/LiteServer.cs
+++ b/src/LiteNetwork.Server/LiteServer.cs
@@ -95,7 +95,7 @@ namespace LiteNetwork.Server
             _acceptor.OnClientAccepted += OnClientAccepted;
             _acceptor.OnError += OnAcceptorError;
 
-            _receiver = new LiteServerReceiver(_packetProcessor, Configuration.ClientBufferSize, Configuration.ReceiveStrategy);
+            _receiver = new LiteServerReceiver(_packetProcessor, Configuration.ReceiveStrategy, Configuration.ClientBufferSize);
             _receiver.Disconnected += OnDisconnected;
             _receiver.Error += OnReceiverError;
 
@@ -294,8 +294,7 @@ namespace LiteNetwork.Server
                 throw new LiteNetworkException($"The accepted socket is null.");
             }
 
-            user.Initialize(e.AcceptSocket, packet => SendTo(user, packet), Configuration.ReceiveStrategy);
-
+            user.Initialize(e.AcceptSocket, packet => SendTo(user, packet));
             _logger?.LogInformation($"New user connected from '{user.Socket.RemoteEndPoint}' with id '{user.Id}'.");
             user.OnConnected();
             _receiver.StartReceiving(user, user.Socket);

--- a/src/LiteNetwork.Server/LiteServer.cs
+++ b/src/LiteNetwork.Server/LiteServer.cs
@@ -52,7 +52,7 @@ namespace LiteNetwork.Server
             _acceptor.OnClientAccepted += OnClientAccepted;
             _acceptor.OnError += OnAcceptorError;
 
-            _receiver = new LiteServerReceiver(_packetProcessor, Configuration.ClientBufferSize);
+            _receiver = new LiteServerReceiver(_packetProcessor, Configuration.ClientBufferSize, Configuration.ReceiveStrategy);
             _receiver.Disconnected += OnDisconnected;
             _receiver.Error += OnReceiverError;
 
@@ -245,8 +245,7 @@ namespace LiteNetwork.Server
                 throw new LiteNetworkException($"The accepted socket is null.");
             }
 
-            user.Socket = e.AcceptSocket;
-            user.SendAction = packet => SendTo(user, packet);
+            user.Initialize(e.AcceptSocket, packet => SendTo(user, packet), Configuration.ReceiveStrategy);
 
             _logger?.LogInformation($"New client connected from '{user.Socket.RemoteEndPoint}' with id '{user.Id}'.");
             user.OnConnected();

--- a/src/LiteNetwork.Server/LiteServerConfiguration.cs
+++ b/src/LiteNetwork.Server/LiteServerConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace LiteNetwork.Server
+﻿using LiteNetwork.Common;
+
+namespace LiteNetwork.Server
 {
     /// <summary>
     /// Provides properties to configure a new <see cref="LiteServer{T}"/> instance.
@@ -34,6 +36,11 @@
         /// Gets the handled client buffer size.
         /// </summary>
         public int ClientBufferSize { get; }
+
+        /// <summary>
+        /// Gets or sets the receive strategy type.
+        /// </summary>
+        public ReceiveStrategyType ReceiveStrategy { get; set; }
 
         /// <summary>
         /// Creates a new empty <see cref="LiteServerConfiguration"/> instance.

--- a/src/LiteNetwork.Server/LiteServerUser.cs
+++ b/src/LiteNetwork.Server/LiteServerUser.cs
@@ -1,7 +1,11 @@
 ﻿using LiteNetwork.Common;
+using LiteNetwork.Common.Internal;
 using LiteNetwork.Protocol.Abstractions;
+using LiteNetwork.Server.Internal;
 using System;
+using System.Collections.Concurrent;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LiteNetwork.Server
@@ -9,6 +13,11 @@ namespace LiteNetwork.Server
     public class LiteServerUser : ILiteConnection
     {
         private bool _disposed;
+        private ReceiveStrategyType _receiveStrategy;
+        private Task _receiveTask = null!;
+        private CancellationToken _receiveProcessCancellationToken;
+        private CancellationTokenSource _receiveProcessCancellationTokenSource = null!;
+        private BlockingCollection<LiteReceivedMessage> _receivedMessages = null!;
 
         /// <inheritdoc />
         public Guid Id { get; } = Guid.NewGuid();
@@ -16,6 +25,10 @@ namespace LiteNetwork.Server
         internal Socket Socket { get; set; } = null!;
 
         internal Action<ILitePacketStream>? SendAction { get; set; }
+
+        public LiteServerUser()
+        {
+        }
 
         /// <inheritdoc />
         public virtual Task HandleMessageAsync(ILitePacketStream incomingPacketStream)
@@ -25,6 +38,57 @@ namespace LiteNetwork.Server
 
         /// <inheritdoc />
         public void Send(ILitePacketStream packet) => SendAction?.Invoke(packet);
+
+        internal void Initialize(Socket socket, Action<ILitePacketStream> sendAction, ReceiveStrategyType receiveStrategyType)
+        {
+            Socket = socket;
+            SendAction = sendAction;
+            _receiveStrategy = receiveStrategyType;
+
+            if (_receiveStrategy == ReceiveStrategyType.Queued)
+            {
+                _receivedMessages = new BlockingCollection<LiteReceivedMessage>();
+                _receiveProcessCancellationTokenSource = new CancellationTokenSource();
+                _receiveProcessCancellationToken = _receiveProcessCancellationTokenSource.Token;
+                _receiveTask = Task.Factory.StartNew(() => ProcessReceivedPackets(),
+                    _receiveProcessCancellationToken,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default);
+            }
+        }
+
+        internal void EnqueueReceivedMessage(LiteReceivedMessage message)
+        {
+            if (_receiveStrategy == ReceiveStrategyType.Queued)
+            {
+                _receivedMessages.Add(message);
+            }
+        }
+
+        private void ProcessReceivedPackets()
+        {
+            if (_receiveStrategy != ReceiveStrategyType.Queued)
+            {
+                return;
+            }
+
+            while (!_receiveProcessCancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    LiteReceivedMessage message = _receivedMessages.Take(_receiveProcessCancellationToken);
+
+                    if (message is not null)
+                    {
+                        message.Handle();
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // The operation has been cancelled: nothing to do
+                }
+            }
+        }
 
         protected internal virtual void OnConnected()
         {
@@ -39,6 +103,19 @@ namespace LiteNetwork.Server
             if (!_disposed)
             {
                 _disposed = true;
+
+                if (_receiveStrategy == ReceiveStrategyType.Queued)
+                {
+                    _receiveProcessCancellationTokenSource.Cancel();
+
+                    while (_receivedMessages.Count > 0)
+                    {
+                        _receivedMessages.Take();
+                    }
+
+                    _receiveTask.Dispose();
+                }
+
                 Socket.Dispose();
             }
         }

--- a/src/LiteNetwork.Server/LiteServerUser.cs
+++ b/src/LiteNetwork.Server/LiteServerUser.cs
@@ -1,11 +1,7 @@
 ﻿using LiteNetwork.Common;
-using LiteNetwork.Common.Internal;
 using LiteNetwork.Protocol.Abstractions;
-using LiteNetwork.Server.Internal;
 using System;
-using System.Collections.Concurrent;
 using System.Net.Sockets;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace LiteNetwork.Server
@@ -16,11 +12,6 @@ namespace LiteNetwork.Server
     public class LiteServerUser : ILiteConnection, IDisposable
     {
         private bool _disposed;
-        private ReceiveStrategyType _receiveStrategy;
-        private Task _receiveTask = null!;
-        private CancellationToken _receiveProcessCancellationToken;
-        private CancellationTokenSource _receiveProcessCancellationTokenSource = null!;
-        private BlockingCollection<LiteReceivedMessage> _receivedMessages = null!;
 
         /// <inheritdoc />
         public Guid Id { get; } = Guid.NewGuid();
@@ -51,55 +42,10 @@ namespace LiteNetwork.Server
         /// <summary>
         /// Called when this user has been connected.
         /// </summary>
-        internal void Initialize(Socket socket, Action<ILitePacketStream> sendAction, ReceiveStrategyType receiveStrategyType)
+        internal void Initialize(Socket socket, Action<ILitePacketStream> sendAction)
         {
             Socket = socket;
             SendAction = sendAction;
-            _receiveStrategy = receiveStrategyType;
-
-            if (_receiveStrategy == ReceiveStrategyType.Queued)
-            {
-                _receivedMessages = new BlockingCollection<LiteReceivedMessage>();
-                _receiveProcessCancellationTokenSource = new CancellationTokenSource();
-                _receiveProcessCancellationToken = _receiveProcessCancellationTokenSource.Token;
-                _receiveTask = Task.Factory.StartNew(() => ProcessReceivedPackets(),
-                    _receiveProcessCancellationToken,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default);
-            }
-        }
-
-        internal void EnqueueReceivedMessage(LiteReceivedMessage message)
-        {
-            if (_receiveStrategy == ReceiveStrategyType.Queued)
-            {
-                _receivedMessages.Add(message);
-            }
-        }
-
-        private void ProcessReceivedPackets()
-        {
-            if (_receiveStrategy != ReceiveStrategyType.Queued)
-            {
-                return;
-            }
-
-            while (!_receiveProcessCancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    LiteReceivedMessage message = _receivedMessages.Take(_receiveProcessCancellationToken);
-
-                    if (message is not null)
-                    {
-                        message.Handle();
-                    }
-                }
-                catch (OperationCanceledException)
-                {
-                    // The operation has been cancelled: nothing to do
-                }
-            }
         }
 
         protected internal virtual void OnConnected()
@@ -121,19 +67,6 @@ namespace LiteNetwork.Server
             if (!_disposed)
             {
                 _disposed = true;
-
-                if (_receiveStrategy == ReceiveStrategyType.Queued)
-                {
-                    _receiveProcessCancellationTokenSource.Cancel();
-
-                    while (_receivedMessages.Count > 0)
-                    {
-                        _receivedMessages.Take();
-                    }
-
-                    _receiveTask.Dispose();
-                }
-
                 Socket.Dispose();
             }
         }


### PR DESCRIPTION
This PR covers issue #20 and introduces the receive strategy type. The strategy can be configured in the `LiteServerConfiguration` class and has the following states:

- `Default` (packets are processed asynchronously right after being received)
- `Queued` (packets are queued in a `BlockingCollection` once they have been received)

Closes #20 