### PR TITLE
Add receive strategy to server builder options

### DIFF
--- a/src/LiteNetwork.Server/Hosting/LiteServerBuilderOptions.cs
+++ b/src/LiteNetwork.Server/Hosting/LiteServerBuilderOptions.cs
@@ -40,6 +40,11 @@ namespace LiteNetwork.Server.Hosting
         public ILitePacketProcessor PacketProcessor { get; set; }
 
         /// <summary>
+        /// Gets or sets the receive strategy type.
+        /// </summary>
+        public ReceiveStrategyType ReceiveStrategy { get; set; }
+
+        /// <summary>
         /// Creates and initializes a new <see cref="LiteServerBuilderOptions"/> instance
         /// with a default <see cref="LitePacketProcessor"/>.
         /// </summary>


### PR DESCRIPTION
This PR covers issue #24 and introduces the `ReceiveStrategy` configuration to the `LiteServerOptionsBuilder` class.

Closes #24 