### PR TITLE
Add host builder extension to specify a server interface

### DIFF
--- a/samples/hosting/LiteNetwork.Samples.Hosting.Server/CustomServer.cs
+++ b/samples/hosting/LiteNetwork.Samples.Hosting.Server/CustomServer.cs
@@ -4,7 +4,12 @@ using System;
 
 namespace LiteNetwork.Samples.Hosting.Server
 {
-    public class CustomServer : LiteServer<ServerUser>
+    public interface ICustomServer
+    {
+        void DoSomething();
+    }
+
+    public class CustomServer : LiteServer<ServerUser>, ICustomServer
     {
         public CustomServer(LiteServerConfiguration configuration, ILitePacketProcessor packetProcessor = null, IServiceProvider serviceProvider = null)
             : base(configuration, packetProcessor, serviceProvider)
@@ -19,6 +24,11 @@ namespace LiteNetwork.Samples.Hosting.Server
         protected override void OnAfterStart()
         {
             Console.WriteLine($"Server listening on port {Configuration.Port}.");
+        }
+
+        public void DoSomething()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/samples/hosting/LiteNetwork.Samples.Hosting.Server/Program.cs
+++ b/samples/hosting/LiteNetwork.Samples.Hosting.Server/Program.cs
@@ -12,7 +12,7 @@ namespace LiteNetwork.Samples.Hosting.Server
             Console.Title = "LiteNetwork Hosting Sample";
 
             var host = new HostBuilder()
-                .UseLiteServer<CustomServer, ServerUser>((host, options) =>
+                .UseLiteServer<ICustomServer, CustomServer, ServerUser>((host, options) =>
                 {
                     options.Host = "127.0.0.1";
                     options.Port = 4444;

--- a/samples/hosting/LiteNetwork.Samples.Hosting.Server/ServerUser.cs
+++ b/samples/hosting/LiteNetwork.Samples.Hosting.Server/ServerUser.cs
@@ -8,6 +8,13 @@ namespace LiteNetwork.Samples.Hosting.Server
 {
     public class ServerUser : LiteServerUser
     {
+        private readonly ICustomServer _server;
+
+        public ServerUser(ICustomServer server)
+        {
+            _server = server;
+        }
+
         public override Task HandleMessageAsync(ILitePacketStream incomingPacketStream)
         {
             string receivedMessage = incomingPacketStream.ReadString();


### PR DESCRIPTION
This PR adds a new extension method to the hosting extensions of the `LiteNetwork.Server` and gives the possibility to specify a server interface:

```csharp
public interface IServer
{
    void DoSomething();
}

public class MyServer : LiteServer<MyServerUser>, IServer
{
    // Implement interface
}
```
then it can be used as followed:
```csharp
hostBuilder.UseLiteNetwork<IServer, MyServer, MyServerUser>(...)
```
Then you can inject in your `MyServerUser` class or any other services the `IServer` in order to have a direct access to the hosting server.