### PR TITLE
Fix requered server service

### DIFF
--- a/src/LiteNetwork.Server/Hosting/LiteServerBuilderExtensions.cs
+++ b/src/LiteNetwork.Server/Hosting/LiteServerBuilderExtensions.cs
@@ -57,7 +57,7 @@ namespace LiteNetwork.Server.Hosting
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.AddSingleton<ILiteServer<TLiteServerUser>, TLiteServer>(serviceProvider =>
+            builder.Services.AddSingleton(serviceProvider =>
             {
                 var liteServerOptions = new LiteServerOptions();
                 configure(liteServerOptions);
@@ -66,7 +66,7 @@ namespace LiteNetwork.Server.Hosting
 
             builder.Services.AddHostedService(serviceProvider =>
             {
-                var serverInstance = serviceProvider.GetRequiredService<ILiteServer<TLiteServerUser>>();
+                var serverInstance = serviceProvider.GetRequiredService<TLiteServer>();
                 return new LiteServerHostedService<TLiteServerUser>(serverInstance);
             });
 

--- a/tests/LiteNetwork.Server.Tests/Hosting/LiteServerHostingTests.cs
+++ b/tests/LiteNetwork.Server.Tests/Hosting/LiteServerHostingTests.cs
@@ -49,7 +49,7 @@ namespace LiteNetwork.Server.Tests.Hosting
 
             using (host)
             {
-                var server = host.Services.GetRequiredService<ILiteServer<CustomUser>>();
+                var server = host.Services.GetRequiredService<CustomServer>();
 
                 Assert.IsType<CustomServer>(server);
                 Assert.True(server is ILiteServer<CustomUser>);


### PR DESCRIPTION
With this PR we are able to get a server instance using DependencyInjection without server interface

e.g.
```csharp 

using Microsoft.Extensions.DependencyInjection;

class Handler {

  private readonly CustomServer _customServer

  public Handler(ServiceProvider provider)
  {
     _customServer = provider.GetRequiredService<CustomServer>();
  }

}
```