### PR TITLE
Feature: make header size configurable

### DIFF
--- a/src/LiteNetwork/Client/LiteClientOptions.cs
+++ b/src/LiteNetwork/Client/LiteClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using LiteNetwork.Protocol;
 using LiteNetwork.Protocol.Abstractions;
+using System;
 
 namespace LiteNetwork.Client
 {
@@ -12,6 +13,11 @@ namespace LiteNetwork.Client
         /// Gets the default buffer allocated size.
         /// </summary>
         public const int DefaultBufferSize = 128;
+
+        /// <summary>
+        /// Gets the default header size, which is 4 bytes (int value).
+        /// </summary>
+        public const int DefaultHeaderSize = 4;
 
         /// <summary>
         /// Gets or sets the remote host to connect.
@@ -29,14 +35,20 @@ namespace LiteNetwork.Client
         public int BufferSize { get; set; } = DefaultBufferSize;
 
         /// <summary>
+        /// TCP packet header size in bytes.
+        /// </summary>
+        public int HeaderSize { get; set; } = DefaultHeaderSize;
+
+        /// <summary>
         /// Gets or sets the receive strategy type.
         /// </summary>
         public ReceiveStrategyType ReceiveStrategy { get; set; }
 
+        private readonly Lazy<ILitePacketProcessor> _lazyPacketProcessor;
         /// <summary>
         /// Gets the default server packet processor.
         /// </summary>
-        public ILitePacketProcessor PacketProcessor { get; set; }
+        public ILitePacketProcessor PacketProcessor { get => _lazyPacketProcessor.Value; }
 
         /// <summary>
         /// Creates and initializes a new <see cref="LiteClientOptions"/> instance
@@ -44,7 +56,7 @@ namespace LiteNetwork.Client
         /// </summary>
         public LiteClientOptions()
         {
-            PacketProcessor = new LitePacketProcessor();
+            _lazyPacketProcessor = new Lazy<ILitePacketProcessor>(() => new LitePacketProcessor(HeaderSize));
         }
     }
 }

--- a/src/LiteNetwork/Client/LiteClientOptions.cs
+++ b/src/LiteNetwork/Client/LiteClientOptions.cs
@@ -17,7 +17,7 @@ namespace LiteNetwork.Client
         /// <summary>
         /// Gets the default header size, which is 4 bytes (int value).
         /// </summary>
-        public const int DefaultHeaderSize = 4;
+        public const int DefaultHeaderSize = sizeof(int);
 
         /// <summary>
         /// Gets or sets the remote host to connect.

--- a/src/LiteNetwork/Protocol/LitePacket.cs
+++ b/src/LiteNetwork/Protocol/LitePacket.cs
@@ -11,7 +11,7 @@ namespace LiteNetwork.Protocol
         /// <summary>
         /// Gets the default <see cref="LitePacket"/> header size. (4 bytes)
         /// </summary>
-        public readonly int HeaderSize = sizeof(int);
+        private readonly int HeaderSize = sizeof(int);
 
         /// <inheritdoc />
         public override byte[] Buffer

--- a/src/LiteNetwork/Protocol/LitePacketProcessor.cs
+++ b/src/LiteNetwork/Protocol/LitePacketProcessor.cs
@@ -9,7 +9,7 @@ namespace LiteNetwork.Protocol
     /// </summary>
     public class LitePacketProcessor : ILitePacketProcessor
     {
-        public LitePacketProcessor(int headerSize = 4)
+        public LitePacketProcessor(int headerSize = sizeof(int))
         {
             HeaderSize = headerSize;
         }

--- a/src/LiteNetwork/Protocol/LitePacketProcessor.cs
+++ b/src/LiteNetwork/Protocol/LitePacketProcessor.cs
@@ -9,15 +9,23 @@ namespace LiteNetwork.Protocol
     /// </summary>
     public class LitePacketProcessor : ILitePacketProcessor
     {
-        public virtual int HeaderSize { get; protected set; } = sizeof(int);
+        public LitePacketProcessor(int headerSize = 4)
+        {
+            HeaderSize = headerSize;
+        }
+
+        public virtual int HeaderSize { get; protected set; }
 
         public virtual bool IncludeHeader { get; protected set; }
 
         public virtual int GetMessageLength(byte[] buffer)
         {
+            if (buffer.Length < sizeof(int))
+                Array.Resize(ref buffer, sizeof(int));
+
             return BitConverter.ToInt32(BitConverter.IsLittleEndian
-                ? buffer.Take(HeaderSize).ToArray()
-                : buffer.Take(HeaderSize).Reverse().ToArray(), 0);
+                ? buffer.Take(sizeof(int)).ToArray()
+                : buffer.Take(sizeof(int)).Reverse().ToArray(), 0);
         }
 
         public virtual ILitePacketStream CreatePacket(byte[] buffer) => new LitePacket(buffer);

--- a/src/LiteNetwork/Protocol/LitePacketProcessor.cs
+++ b/src/LiteNetwork/Protocol/LitePacketProcessor.cs
@@ -9,7 +9,12 @@ namespace LiteNetwork.Protocol
     /// </summary>
     public class LitePacketProcessor : ILitePacketProcessor
     {
-        public LitePacketProcessor(int headerSize = sizeof(int))
+        public LitePacketProcessor()
+        {
+            HeaderSize = sizeof(int);
+        }
+
+        public LitePacketProcessor(int headerSize)
         {
             HeaderSize = headerSize;
         }

--- a/src/LiteNetwork/Server/LiteServer.cs
+++ b/src/LiteNetwork/Server/LiteServer.cs
@@ -21,7 +21,7 @@ namespace LiteNetwork.Server
     /// <typeparam name="TUser">The user type that the server will be use.</typeparam>
     public class LiteServer<TUser> : ILiteServer<TUser> where TUser : LiteServerUser
     {
-        private readonly ILogger<LiteServer<TUser>>? _logger;
+        protected readonly ILogger<LiteServer<TUser>>? _logger;
         private readonly IServiceProvider _serviceProvider;
         private readonly ConcurrentDictionary<Guid, TUser> _connectedUsers;
         private readonly Socket _socket;

--- a/src/LiteNetwork/Server/LiteServerOptions.cs
+++ b/src/LiteNetwork/Server/LiteServerOptions.cs
@@ -17,7 +17,7 @@ namespace LiteNetwork.Server
         /// <summary>
         /// Gets the default header size, which is 4 bytes (int value).
         /// </summary>
-        public const int DefaultHeaderSize = 4;
+        public const int DefaultHeaderSize = sizeof(int);
 
         /// <summary>
         /// Gets the default client buffer allocated size.

--- a/src/LiteNetwork/Server/LiteServerOptions.cs
+++ b/src/LiteNetwork/Server/LiteServerOptions.cs
@@ -1,5 +1,6 @@
 ﻿using LiteNetwork.Protocol;
 using LiteNetwork.Protocol.Abstractions;
+using System;
 
 namespace LiteNetwork.Server
 {
@@ -12,6 +13,11 @@ namespace LiteNetwork.Server
         /// Gets the default maximum of connections in accept queue.
         /// </summary>
         public const int DefaultBacklog = 50;
+
+        /// <summary>
+        /// Gets the default header size, which is 4 bytes (int value).
+        /// </summary>
+        public const int DefaultHeaderSize = 4;
 
         /// <summary>
         /// Gets the default client buffer allocated size.
@@ -39,14 +45,21 @@ namespace LiteNetwork.Server
         public int ClientBufferSize { get; set; } = DefaultClientBufferSize;
 
         /// <summary>
+        /// TCP packet header size in bytes.
+        /// </summary>
+        public int HeaderSize { get; set; } = DefaultHeaderSize;
+
+        /// <summary>
         /// Gets or sets the receive strategy type.
         /// </summary>
         public ReceiveStrategyType ReceiveStrategy { get; set; }
 
+        private readonly Lazy<ILitePacketProcessor> _lazyPacketProcessor;
+
         /// <summary>
         /// Gets the default server packet processor.
         /// </summary>
-        public ILitePacketProcessor PacketProcessor { get; set; }
+        public ILitePacketProcessor PacketProcessor { get => _lazyPacketProcessor.Value; }
 
         /// <summary>
         /// Creates and initializes a new <see cref="LiteServerOptions"/> instance
@@ -54,7 +67,7 @@ namespace LiteNetwork.Server
         /// </summary>
         public LiteServerOptions()
         {
-            PacketProcessor = new LitePacketProcessor();
+            _lazyPacketProcessor = new Lazy<ILitePacketProcessor>(() => new LitePacketProcessor(HeaderSize));
         }
     }
 }

--- a/tests/LiteNetwork.Protocol.Tests/DefaultPacketProcessorTests.cs
+++ b/tests/LiteNetwork.Protocol.Tests/DefaultPacketProcessorTests.cs
@@ -51,5 +51,20 @@ namespace LiteNetwork.Protocol.Tests
         {
             Assert.False(_packetProcessor.IncludeHeader);
         }
+
+        [Theory]
+        [InlineData(35)]
+        [InlineData(23)]
+        [InlineData(0x4A)]
+        [InlineData(0)]
+        public void DefaultPacketProcessorCanHaveConfigurableHeaderSize(short headerValue)
+        {
+            var packetProcessor = new LitePacketProcessor(sizeof(short));
+
+            var headerBuffer = BitConverter.GetBytes(headerValue);
+            int packetSize = packetProcessor.GetMessageLength(headerBuffer);
+
+            Assert.Equal(headerValue, packetSize);
+        }
     }
 }

--- a/tests/LiteNetwork.Protocol.Tests/LitePacketTests.cs
+++ b/tests/LiteNetwork.Protocol.Tests/LitePacketTests.cs
@@ -81,5 +81,29 @@ namespace LiteNetwork.Protocol.Tests
 
             packet.Dispose();
         }
+
+        [Fact]
+        public void CreatePacketWithCustomHeaderSize()
+        {
+            const int HeaderSize = sizeof(ushort);
+            const int DataSize = sizeof(short) + sizeof(float);
+            var shortValue = _randomizer.Short();
+            var floatValue = _randomizer.Float();
+
+            var packet = new LitePacket(HeaderSize);
+
+            packet.Write(shortValue);
+            packet.Write(floatValue);
+
+            Assert.Equal(LitePacketMode.Write, packet.Mode);
+            Assert.NotNull(packet.Buffer);
+            Assert.Equal(HeaderSize + DataSize, packet.Buffer.Length);
+            Assert.Equal(DataSize, packet.ContentLength);
+            Assert.Equal(DataSize, BitConverter.ToInt16(packet.Buffer, 0));
+            Assert.Equal(shortValue, BitConverter.ToInt16(packet.Buffer, HeaderSize));
+            Assert.Equal(floatValue, BitConverter.ToSingle(packet.Buffer, HeaderSize + sizeof(short)));
+
+            packet.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Hi 😄 
I would like to introduce another feature for `LitePacketProcessor`. I know you can already parse custom headers as per https://github.com/Eastrall/LiteNetwork/pull/19 . But I find it more comfortable, if packet header of **fixed** size can be configurated via options. So I propose to add another configuration:
```
public const int DefaultHeaderSize = 4;
public int HeaderSize { get; set; } = DefaultHeaderSize;
```
This should be by default 4 (int size) and can be change to any other value, e.g. 2 bytes (short size).

CC @Eastrall 