### PR TITLE
Lite data token connection

### DIFF
--- a/src/LiteNetwork/Internal/Tokens/LiteDefaultConnectionToken.cs
+++ b/src/LiteNetwork/Internal/Tokens/LiteDefaultConnectionToken.cs
@@ -27,7 +27,7 @@ namespace LiteNetwork.Internal.Tokens
         {
             Connection = connection;
             _handlerAction = handlerAction;
-            DataToken = new LiteDataToken();
+            DataToken = new LiteDataToken(Connection);
         }
 
         /// <inheritdoc />

--- a/src/LiteNetwork/Internal/Tokens/LiteQueuedConnectionToken.cs
+++ b/src/LiteNetwork/Internal/Tokens/LiteQueuedConnectionToken.cs
@@ -32,7 +32,7 @@ namespace LiteNetwork.Internal.Tokens
         {
             Connection = connection;
             _handlerAction = handlerAction;
-            DataToken = new LiteDataToken();
+            DataToken = new LiteDataToken(Connection);
             _receiveMessageQueue = new BlockingCollection<byte[]>();
             _receiveCancellationTokenSource = new CancellationTokenSource();
             _receiveCancellationToken = _receiveCancellationTokenSource.Token;

--- a/src/LiteNetwork/LiteNetwork.csproj
+++ b/src/LiteNetwork/LiteNetwork.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<Authors>Filipe GOMES PEIXOTO</Authors>
 		<Product>LiteNetwork</Product>
 		<Copyright>Filipe GOMES PEIXOTO © 2019-2021</Copyright>
@@ -19,8 +19,8 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<NeutralLanguage>en-001</NeutralLanguage>
-		<AssemblyVersion>1.0.2</AssemblyVersion>
-		<FileVersion>1.0.2</FileVersion>
+		<AssemblyVersion>1.0.3</AssemblyVersion>
+		<FileVersion>1.0.3</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(TargetFramework)' == 'netstandard2.0')">

--- a/src/LiteNetwork/Protocol/LiteDataToken.cs
+++ b/src/LiteNetwork/Protocol/LiteDataToken.cs
@@ -1,4 +1,6 @@
-﻿namespace LiteNetwork.Protocol
+﻿using System;
+
+namespace LiteNetwork.Protocol
 {
     /// <summary>
     /// Provides a data structure that defines a lite packet data.
@@ -44,6 +46,21 @@
         /// Gets a value that indicates if the message is complete.
         /// </summary>
         public bool IsMessageComplete => MessageSize.HasValue && ReceivedMessageBytesCount == MessageSize.Value;
+
+        /// <summary>
+        /// Gets the connection attached to the current data token.
+        /// </summary>
+        public ILiteConnection Connection { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="LiteDataToken"/> instance.
+        /// </summary>
+        /// <param name="connection">Current connection attached to this data token.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the given connection is null.</exception>
+        public LiteDataToken(ILiteConnection connection)
+        {
+            Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        }
 
         /// <summary>
         /// Reset the token data properties.

--- a/tests/LiteNetwork.Protocol.Tests/LitePacketParserTests.cs
+++ b/tests/LiteNetwork.Protocol.Tests/LitePacketParserTests.cs
@@ -2,6 +2,7 @@
 using LiteNetwork.Protocol.Abstractions;
 using LiteNetwork.Protocol.Internal;
 using LiteNetwork.Protocol.Tests.Processors;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,7 +43,8 @@ namespace LiteNetwork.Protocol.Tests
         public void ParseIncomingDataTest(int bytesTransfered)
         {
             _packetParser = new LitePacketParser(_packetProcessor);
-            var token = new LiteDataToken();
+            var connection = new Mock<ILiteConnection>();
+            var token = new LiteDataToken(connection.Object);
             var numberOfReceivesNeeded = _buffer.Length / bytesTransfered + 1;
             var receviedMessages = new List<byte[]>();
 
@@ -73,7 +75,8 @@ namespace LiteNetwork.Protocol.Tests
         {
             _packetParser = new LitePacketParser(new DefaultLitePacketProcessor(includeHeader: true));
 
-            var token = new LiteDataToken();
+            var connection = new Mock<ILiteConnection>();
+            var token = new LiteDataToken(connection.Object);
             var numberOfReceivesNeeded = _buffer.Length / bytesTransfered + 1;
             var receviedMessages = new List<byte[]>();
 
@@ -99,7 +102,8 @@ namespace LiteNetwork.Protocol.Tests
         public void ParseIncomingDataWithInvalidSizeTest()
         {
             _packetParser = new LitePacketParser(_packetProcessor);
-            var token = new LiteDataToken();
+            var connection = new Mock<ILiteConnection>();
+            var token = new LiteDataToken(connection.Object);
 
             Assert.Throws<InvalidOperationException>(() => _packetParser.ParseIncomingData(token, _invalidBuffer, 32));
         }

--- a/tests/LiteNetwork.Protocol.Tests/LitePacketParserWithCustomProcessor.cs
+++ b/tests/LiteNetwork.Protocol.Tests/LitePacketParserWithCustomProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using LiteNetwork.Protocol.Internal;
 using LiteNetwork.Protocol.Tests.Processors;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -84,7 +85,8 @@ namespace LiteNetwork.Protocol.Tests
 
         public LitePacketParserWithCustomProcessor()
         {
-            _token = new LiteDataToken();
+            var connection = new Mock<ILiteConnection>();
+            _token = new LiteDataToken(connection.Object);
             _packetParser = new LitePacketParser(new CustomVariablePacketProcessor());
         }
 


### PR DESCRIPTION
This PR covers issue #44. It adds the current `ILiteConnection` to the current packet being processed by a packet processor. 

The connection is stored in the `LiteDataToken` that is consumed by a `IPacketProcessor`.