### PR TITLE
Add support for IPAddress.Any

### DIFF
--- a/src/LiteNetwork/Internal/LiteNetworkHelpers.cs
+++ b/src/LiteNetwork/Internal/LiteNetworkHelpers.cs
@@ -20,9 +20,11 @@ namespace LiteNetwork.Internal
         /// The result returns a <see cref="IPEndPoint"/> with the specified IP or host and port number.></returns>
         public static async Task<IPEndPoint> CreateIpEndPointAsync(string ipOrHost, int port)
         {
-            IPAddress[] addresses = await Dns.GetHostAddressesAsync(ipOrHost).ConfigureAwait(false);
+            IPAddress address = ipOrHost == IPAddress.Any.ToString() ?
+                IPAddress.Any :
+                (await Dns.GetHostAddressesAsync(ipOrHost).ConfigureAwait(false)).First(x => x.AddressFamily == AddressFamily.InterNetwork);
 
-            return new IPEndPoint(addresses.First(x => x.AddressFamily == AddressFamily.InterNetwork), port);
+            return new IPEndPoint(address, port);
         }
     }
 }

--- a/src/LiteNetwork/LiteNetwork.csproj
+++ b/src/LiteNetwork/LiteNetwork.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 		<Authors>Filipe GOMES PEIXOTO</Authors>
 		<Product>LiteNetwork</Product>
 		<Copyright>Filipe GOMES PEIXOTO © 2019-2022</Copyright>
@@ -19,8 +19,8 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<NeutralLanguage>en-001</NeutralLanguage>
-		<AssemblyVersion>2.0.0</AssemblyVersion>
-		<FileVersion>2.0.0</FileVersion>
+		<AssemblyVersion>2.1.0</AssemblyVersion>
+		<FileVersion>2.1.0</FileVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 

--- a/tests/LiteNetwork.Common.Tests/NetHelperTests.cs
+++ b/tests/LiteNetwork.Common.Tests/NetHelperTests.cs
@@ -7,18 +7,11 @@ namespace LiteNetwork.Network.Tests
     public class NetHelperTests
     {
         [Theory]
-        [InlineData("0.0.0.0")]
-        public void BuildUnspecifiedAddress(string ipOrHost)
-        {
-            Assert.ThrowsAsync<ArgumentException>(() => LiteNetworkHelpers.CreateIpEndPointAsync(ipOrHost, 4444));
-        }
-
-
-        [Theory]
         [InlineData("127.0.0.1", 4444)]
         [InlineData("92.5.1.44", 8080)]
         [InlineData("156.16.255.55", 4444)]
         [InlineData("", 8080)]
+        [InlineData("0.0.0.0", 4444)]
         public async void CreateValidIPEndPoint(string ipAddress, int port)
         {
             var ipEndPoint = await LiteNetworkHelpers.CreateIpEndPointAsync(ipAddress, port);


### PR DESCRIPTION
Covers issue #54 and adds support for `IPAddress.Any`. To use it, set the `LiteServerOptions.Host` property to `0.0.0.0`.